### PR TITLE
Fetch the fingerprint via HTTPS.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,19 +3,15 @@ import Transport from "./transport"
 
 const params = new URLSearchParams(window.location.search)
 
-const url = params.get("url") || "https://localhost:4443/watch"
-const canvas = document.querySelector<HTMLCanvasElement>("canvas#video")!
+const url = params.get("url") || "https://localhost:4443"
+const fingerprintUrl = url + "/fingerprint"
 
 const transport = new Transport({
-	url: url,
-	/*
-	fingerprint: {
-		// TODO remove when Chrome accepts the system CA
-		algorithm: "sha-256",
-		value: new Uint8Array(fingerprint),
-	},
-	*/
+	url,
+	fingerprintUrl,
 })
+
+const canvas = document.querySelector<HTMLCanvasElement>("canvas#video")!
 
 const player = new Player({
 	transport,

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -3,7 +3,10 @@ import * as Interface from "./interface"
 
 export interface Config {
 	url: string
-	fingerprint?: WebTransportHash // the certificate fingerprint, temporarily needed for local development
+
+	// If set, the server fingerprint will be fetched from this URL.
+	// This is required to use self-signed certificates with Chrome (May 2023)
+	fingerprintUrl?: string
 }
 
 export default class Transport {
@@ -24,14 +27,39 @@ export default class Transport {
 	}
 
 	async close() {
-		;(await this.quic).close()
+		(await this.quic).close()
+	}
+
+	private async fingerprint(url: string): Promise<WebTransportHash> {
+		// TODO remove this fingerprint when Chrome WebTransport accepts the system CA
+		const response = await fetch(url);
+		const hexString = await response.text();
+
+		console.log(hexString);
+
+		let hexBytes = new Uint8Array(hexString.length / 2);
+		for (let i = 0; i < hexBytes.length; i += 1) {
+			hexBytes[i] = parseInt(hexString.slice(2*i, 2*i + 2), 16);
+		}
+
+		return {
+			algorithm: "sha-256",
+			value: hexBytes,
+		}
 	}
 
 	// Helper function to make creating a promise easier
 	private async connect(config: Config): Promise<WebTransport> {
 		const options: WebTransportOptions = {}
-		if (config.fingerprint) {
-			options.serverCertificateHashes = [config.fingerprint]
+
+		if (config.fingerprintUrl) {
+			try {
+				const fingerprint = await this.fingerprint(config.fingerprintUrl);
+				console.log(fingerprint)
+				options.serverCertificateHashes = [ fingerprint ]
+			} catch (e) {
+				console.warn("failed to fetch fingerprint: ", e)
+			}
 		}
 
 		const quic = new WebTransport(config.url, options)

--- a/src/transport/index.ts
+++ b/src/transport/index.ts
@@ -27,19 +27,17 @@ export default class Transport {
 	}
 
 	async close() {
-		(await this.quic).close()
+		;(await this.quic).close()
 	}
 
 	private async fingerprint(url: string): Promise<WebTransportHash> {
 		// TODO remove this fingerprint when Chrome WebTransport accepts the system CA
-		const response = await fetch(url);
-		const hexString = await response.text();
+		const response = await fetch(url)
+		const hexString = await response.text()
 
-		console.log(hexString);
-
-		let hexBytes = new Uint8Array(hexString.length / 2);
+		const hexBytes = new Uint8Array(hexString.length / 2)
 		for (let i = 0; i < hexBytes.length; i += 1) {
-			hexBytes[i] = parseInt(hexString.slice(2*i, 2*i + 2), 16);
+			hexBytes[i] = parseInt(hexString.slice(2 * i, 2 * i + 2), 16)
 		}
 
 		return {
@@ -54,9 +52,9 @@ export default class Transport {
 
 		if (config.fingerprintUrl) {
 			try {
-				const fingerprint = await this.fingerprint(config.fingerprintUrl);
+				const fingerprint = await this.fingerprint(config.fingerprintUrl)
 				console.log(fingerprint)
-				options.serverCertificateHashes = [ fingerprint ]
+				options.serverCertificateHashes = [fingerprint]
 			} catch (e) {
 				console.warn("failed to fetch fingerprint: ", e)
 			}


### PR DESCRIPTION
It's less efficient but it allows warp-rs and warp-js to be separate repositories.