### PR TITLE
Fix error 404 on route change

### DIFF
--- a/web/nav.html
+++ b/web/nav.html
@@ -5,13 +5,13 @@
 			<img src="nav/logo.svg" width="200" alt="Media over QUIC" />
 		</a>
 		<div class="flex flex-row flex-wrap items-center justify-start gap-4 p-4 sm:justify-center">
-			<a href="watch">
+			<a href="watch.html">
 				<img src="nav/watch.svg" width="120" alt="Watch" />
 			</a>
-			<a href="publish">
+			<a href="publish.html">
 				<img src="nav/publish.svg" width="120" alt="Publish" />
 			</a>
-			<a href="explain">
+			<a href="explain.html">
 				<img src="nav/explain.svg" width="120" alt="Explain" />
 			</a>
 			<a href="https://github.com/kixelated/moq-js">


### PR DESCRIPTION
When I try to access the routes `watch`, `publish` or `explain` I receive a 404 error. (I'm using Brave)

But it works when I update the routes to finish with `.html`. So here is a fix.