### PR TITLE
Stream Link on Watch Page

### DIFF
--- a/web/src/pages/watch/index.mdx
+++ b/web/src/pages/watch/index.mdx
@@ -4,7 +4,14 @@ title: Watch
 ---
 
 # Public Broadcasts
+* [Bunny Stream](https://quic.video/watch/bbb)
 
-Public broadcasts will be listed here; we're <a href="/issues">busy</a> setting up the CDN.
+*Currently this is mock example with a working video for your enjoyment*
 
-In the meantime, <a href="/publish">PUBLISH</a> and share the resulting link.
+All **PUBLIC** broadcasts will be eventually listed here; we're <a href="/issues">busy</a> setting up the CDN.
+
+***
+### Next Steps
+In the meantime, feel free to <a href="/publish">PUBLISH</a> and share your resulting link.
+
+


### PR DESCRIPTION
+ the video running 24/7 at the [this address](https://quic.video/watch/bbb) has been added to the watch page as a current place holder in a list that will later be populated with actual live streams. 

+ only the index.mdx file was edited, changed some wording and moved sections around.

I'll be coming back to this page in issue #49 and reformatting the layout as well. 