### PR TITLE
remove frame rate check

### DIFF
--- a/lib/media/catalog/index.ts
+++ b/lib/media/catalog/index.ts
@@ -112,7 +112,6 @@ export function isVideoTrack(track: any): track is VideoTrack {
 	if (typeof track.codec !== "string") return false
 	if (typeof track.width !== "number") return false
 	if (typeof track.height !== "number") return false
-	if (typeof track.frame_rate !== "number") return false
 	if (!isTrack(track)) return false
 	return true
 }


### PR DESCRIPTION
This PR removes the frame rate check from Catalog.isVideoTrack method.

Fixes #79 