### PR TITLE
Issues in boxing of opus encoded audio

### DIFF
--- a/lib/contribute/container.ts
+++ b/lib/contribute/container.ts
@@ -64,6 +64,7 @@ export class Container {
 			const data = new MP4.Stream(desc, 8, MP4.Stream.LITTLE_ENDIAN)
 			dops.parse(data)
 
+			dops.Version = 0
 			options.description = dops
 			options.hdlr = "soun"
 		} else {

--- a/lib/contribute/container.ts
+++ b/lib/contribute/container.ts
@@ -65,6 +65,7 @@ export class Container {
 			dops.parse(data)
 
 			options.description = dops
+			options.hdlr = "soun"
 		} else {
 			throw new Error(`unsupported codec: ${codec}`)
 		}


### PR DESCRIPTION
Looking at output of ffprobe before and after -

Before:

```
[mov,mp4,m4a,3gp,3g2,mj2 @ 0x563823388ec0] overread end of atom 'stsd' by 31 bytes
[mov,mp4,m4a,3gp,3g2,mj2 @ 0x563823388ec0] Could not find codec parameters for stream 0 (Video: none (Opus / 0x7375704F), none, 48000x0): unknown codec
Consider increasing the value for the 'analyzeduration' (0) and 'probesize' (5000000) options
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'dump/audio-init.mp4':
  Metadata:
    major_brand     : iso4
    minor_version   : 0
    compatible_brands: iso4
  Duration: N/A, bitrate: N/A
  Stream #0:0(eng): Video: none (Opus / 0x7375704F), none, 48000x0, 1000k tbr, 1000k tbn, 1000k tbc (default)
    Metadata:
      handler_name    : Track created with MP4Box.js
      vendor_id       : [0][0][0][0]
      encoder         : Ä
    Side data:
      displaymatrix: rotation of nan degrees
Unsupported codec with id 0 for input stream 0
```
After:
```
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'dump/audio-init.mp4':
  Metadata:
    major_brand     : iso4
    minor_version   : 0
    compatible_brands: iso4
  Duration: N/A, bitrate: N/A
  Stream #0:0(eng): Audio: opus (Opus / 0x7375704F), 48000 Hz, stereo, fltp (default)
    Metadata:
      handler_name    : Track created with MP4Box.js
      vendor_id       : [0][0][0][0]

```
