### PR TITLE
Switch broadcasts from a name to a path.

### DIFF
--- a/lib/contribute/broadcast.ts
+++ b/lib/contribute/broadcast.ts
@@ -6,7 +6,7 @@ import * as Video from "./video"
 import { isAudioTrackSettings, isVideoTrackSettings } from "../common/settings"
 
 export interface BroadcastConfig {
-	name: string
+	path: string[]
 	media: MediaStream
 
 	audio?: AudioEncoderConfig
@@ -24,11 +24,11 @@ export class Broadcast {
 
 	constructor(config: BroadcastConfig) {
 		this.#config = config
-		this.#broadcast = new Transfork.Broadcast(config.name)
+		this.#broadcast = new Transfork.Broadcast(config.path)
 	}
 
 	async publish(connection: Transfork.Connection) {
-		const broadcast: Catalog.Broadcast = { name: this.#config.name, audio: [], video: [] }
+		const broadcast: Catalog.Broadcast = { path: this.#config.path, audio: [], video: [] }
 
 		for (const media of this.#config.media.getTracks()) {
 			const settings = media.getSettings()

--- a/lib/karp/catalog/broadcast.ts
+++ b/lib/karp/catalog/broadcast.ts
@@ -3,7 +3,7 @@ import { decodeAudio, Audio } from "./audio"
 import { decodeVideo, Video } from "./video"
 
 export interface Broadcast {
-	name: string
+	path: string[]
 	video: Video[]
 	audio: Audio[]
 }
@@ -15,7 +15,7 @@ export function encode(catalog: Broadcast): Uint8Array {
 	return encoder.encode(str)
 }
 
-export function decode(broadcast: string, raw: Uint8Array): Broadcast {
+export function decode(path: string[], raw: Uint8Array): Broadcast {
 	const decoder = new TextDecoder()
 	const str = decoder.decode(raw)
 
@@ -24,12 +24,12 @@ export function decode(broadcast: string, raw: Uint8Array): Broadcast {
 		throw new Error("invalid catalog")
 	}
 
-	catalog.name = broadcast
+	catalog.path = path
 	return catalog
 }
 
-export async function fetch(connection: Transfork.Connection, broadcast: string): Promise<Broadcast> {
-	const track = new Transfork.Track(broadcast, "catalog.json", 0)
+export async function fetch(connection: Transfork.Connection, path: string[]): Promise<Broadcast> {
+	const track = new Transfork.Track(path, "catalog.json", 0)
 	const sub = await connection.subscribe(track)
 	try {
 		const segment = await sub.nextGroup()
@@ -39,7 +39,7 @@ export async function fetch(connection: Transfork.Connection, broadcast: string)
 		if (!frame) throw new Error("no catalog frame")
 
 		segment.close()
-		return decode(broadcast, frame)
+		return decode(path, frame)
 	} finally {
 		sub.close()
 	}

--- a/lib/playback/player.ts
+++ b/lib/playback/player.ts
@@ -62,8 +62,8 @@ export class Player {
 	}
 
 	async #runAudio(audio: Catalog.Audio) {
-		const track = new Track(this.#broadcast.name, audio.track.name, audio.track.priority)
-		const sub = await this.#connection.subscribe(new Track(this.#broadcast.name, track.name, track.priority))
+		const track = new Track(this.#broadcast.path, audio.track.name, audio.track.priority)
+		const sub = await this.#connection.subscribe(new Track(this.#broadcast.path, track.name, track.priority))
 
 		try {
 			for (;;) {
@@ -80,8 +80,8 @@ export class Player {
 	}
 
 	async #runVideo(video: Catalog.Video) {
-		const track = new Track(this.#broadcast.name, video.track.name, video.track.priority)
-		const sub = await this.#connection.subscribe(new Track(this.#broadcast.name, track.name, track.priority))
+		const track = new Track(this.#broadcast.path, video.track.name, video.track.priority)
+		const sub = await this.#connection.subscribe(new Track(this.#broadcast.path, track.name, track.priority))
 
 		try {
 			for (;;) {

--- a/lib/transfork/connection.ts
+++ b/lib/transfork/connection.ts
@@ -50,7 +50,7 @@ export class Connection {
 		this.#publisher.announce(broadcast)
 	}
 
-	async announced(prefix = ""): Promise<Queue<Announced>> {
+	async announced(prefix = []): Promise<Queue<Announced>> {
 		return this.#subscriber.announced(prefix)
 	}
 

--- a/lib/transfork/model.ts
+++ b/lib/transfork/model.ts
@@ -7,11 +7,11 @@ export class Broadcast {
 	readers = 0
 	closed?: Closed
 
-	constructor(public name: string) {}
+	constructor(public path: string[]) {}
 
 	createTrack(name: string, priority: number): Track {
 		if (this.closed) throw this.closed
-		const track = new Track(this.name, name, priority)
+		const track = new Track(this.path, name, priority)
 		track.readers += 1 // Avoid closing the track when all readers are closed
 		this.tracks.set(track.name, track)
 		return track
@@ -41,8 +41,8 @@ export class BroadcastReader {
 		}
 	}
 
-	get name(): string {
-		return this.#broadcast.name
+	get path(): string[] {
+		return this.#broadcast.path
 	}
 
 	close() {
@@ -52,7 +52,7 @@ export class BroadcastReader {
 }
 
 export class Track {
-	readonly broadcast: string
+	readonly broadcast: string[]
 	readonly name: string
 	readonly priority: number
 	order = Order.Any
@@ -63,7 +63,7 @@ export class Track {
 	readers = 0
 	closed?: Closed
 
-	constructor(broadcast: string, name: string, priority: number) {
+	constructor(broadcast: string[], name: string, priority: number) {
 		this.broadcast = broadcast
 		this.name = name
 		this.priority = priority

--- a/lib/transfork/stream.ts
+++ b/lib/transfork/stream.ts
@@ -159,6 +159,17 @@ export class Reader {
 		return new TextDecoder().decode(buffer)
 	}
 
+	async path(): Promise<string[]> {
+		const parts = await this.u53()
+		const path = []
+
+		for (let i = 0; i < parts; i++) {
+			path.push(await this.string())
+		}
+
+		return path
+	}
+
 	async u8(): Promise<number> {
 		await this.#fillTo(1)
 		return this.#slice(1)[0]
@@ -298,6 +309,13 @@ export class Writer {
 		const data = new TextEncoder().encode(str)
 		await this.u53(data.byteLength)
 		await this.write(data)
+	}
+
+	async path(path: string[]) {
+		await this.u53(path.length)
+		for (const part of path) {
+			await this.string(part)
+		}
 	}
 
 	async close() {

--- a/web/src/components/publish.tsx
+++ b/web/src/components/publish.tsx
@@ -145,7 +145,7 @@ export default function Publish() {
 		}
 
 		return new Broadcast({
-			name: name,
+			path: [name],
 			media: d,
 			audio: a,
 			video: v,

--- a/web/src/components/watch.tsx
+++ b/web/src/components/watch.tsx
@@ -4,10 +4,10 @@ import * as Catalog from "@kixelated/moq/karp/catalog"
 
 import Fail from "./fail"
 
-import { createEffect, createSignal, onCleanup, onMount, Show } from "solid-js"
+import { createEffect, createSignal, onCleanup } from "solid-js"
 import { Client, Connection } from "@kixelated/moq/transfork"
 
-export default function Watch(props: { name: string }) {
+export default function Watch(props: { path: string[] }) {
 	// Use query params to allow overriding environment variables.
 	const urlSearchParams = new URLSearchParams(window.location.search)
 	const params = Object.fromEntries(urlSearchParams.entries())
@@ -40,7 +40,7 @@ export default function Watch(props: { name: string }) {
 		const connection = useConnection()
 		if (!connection) return
 
-		Catalog.fetch(connection, props.name)
+		Catalog.fetch(connection, props.path)
 			.then(setCatalog)
 			.catch((err) => setError(new Error(`failed to fetch catalog: ${err}`)))
 	})
@@ -62,7 +62,7 @@ export default function Watch(props: { name: string }) {
 	})
 
 	const play = () => {
-		usePlayer()?.play().catch(setError)
+		usePlayer()?.play()
 	}
 
 	// NOTE: The canvas automatically has width/height set to the decoded video size.

--- a/web/src/pages/watch/[...path].astro
+++ b/web/src/pages/watch/[...path].astro
@@ -1,19 +1,21 @@
 ---
 export const prerender = false
 
-const { name } = Astro.params
-if (!name) return Astro.redirect("/404")
+const { path } = Astro.params
+if (!path) return Astro.redirect("/404")
+
+const parts = path.split("/")
 
 import Issues from "@/components/issues.astro"
 import Watch from "@/components/watch.tsx"
 import Layout from "@/layouts/global.astro"
 ---
 
-<Layout title={`Watch - ${name}`}>
+<Layout title={`Watch - ${path}`}>
 	<Issues />
 
 	<p>
 		Watching a <strong>PUBLIC</strong> broadcast. Pls report any abuse.
 	</p>
-	<Watch name={name} client:only />
+	<Watch path={parts} client:only />
 </Layout>


### PR DESCRIPTION
Avoids awkward issues with delimiters.
Will fully utilize for (new) broadcast discovery,
instead of running into duplicate errors.
instead of running into duplicate errors.